### PR TITLE
feat: add fix for unsigned integer array types, use capturing groups for integer array fixes

### DIFF
--- a/dist/fixes.js
+++ b/dist/fixes.js
@@ -43,10 +43,17 @@ exports.fixes = {
         //
         // current solution: use sequence<float> type
         return idlString
-            .replace(/attribute (\w+)\[\]/gi, function (match, group) {
+            .replace(/attribute unsigned (\w+)\[\]/gi, function (_, group) {
+            return "attribute FrozenArray<unsigned " + group + ">";
+        })
+            .replace(/attribute (\w+)\[\]/gi, function (_, group) {
             return "attribute FrozenArray<" + group + ">";
         })
-            .replace(/float\[\]/gi, 'FrozenArray<float>')
-            .replace(/long\[\]/gi, 'FrozenArray<long>');
+            .replace(/unsigned (\w+)\[\]/gi, function (_, group) {
+            return "FrozenArray<unsigned " + group + ">";
+        })
+            .replace(/(\w+)\[\]/gi, function (_, group) {
+            return "FrozenArray<" + group + ">";
+        });
     },
 };

--- a/src/fixes.ts
+++ b/src/fixes.ts
@@ -40,10 +40,17 @@ export const fixes = {
     //
     // current solution: use sequence<float> type
     return idlString
-      .replace(/attribute (\w+)\[\]/gi, (match, group) => {
+      .replace(/attribute unsigned (\w+)\[\]/gi, (_, group) => {
+        return `attribute FrozenArray<unsigned ${group}>`
+      })
+      .replace(/attribute (\w+)\[\]/gi, (_, group) => {
         return `attribute FrozenArray<${group}>`
       })
-      .replace(/float\[\]/gi, 'FrozenArray<float>')
-      .replace(/long\[\]/gi, 'FrozenArray<long>')
+      .replace(/unsigned (\w+)\[\]/gi, (_, group) => {
+        return `FrozenArray<unsigned ${group}>`
+      })
+      .replace(/(\w+)\[\]/gi, (_, group) => {
+        return `FrozenArray<${group}>`
+      })
   },
 }


### PR DESCRIPTION
- add fix for unsigned integer array types
- use capture groups for array fixes
  - prevents needing to specify all types, e.g. `float`, `long`, others